### PR TITLE
Do not use a directory for each RFD

### DIFF
--- a/rfd/rfd-0000.md
+++ b/rfd/rfd-0000.md
@@ -193,6 +193,6 @@ $ git push
 
 RFDs may need to be revised after they have been moved into the
 `publish` state.  If the changes are minor then you SHOULD update the
-RFD but if they the changes are similar to those in Section 1.1 you
+RFD but if the changes are similar to those in Section 1.1 you
 SHOULD abandon the current RFD and start a new one.
 

--- a/rfd/rfd-0000.md
+++ b/rfd/rfd-0000.md
@@ -104,9 +104,9 @@ To create a new RFD, you MUST take the following steps.
 RFDs are numbered starting at 0, this RFD, and then increase from
 there. When you start, you MUST allocate the next currently unused
 number. Note that if someone puts back to the repository before you,
-then you MUST just increase your number to the next available one. If,
-if the next RFD would be number 42, then you should make the directory
-0042 and place it in the file 0042.md. Note, that while we use four
+then you MUST increase your number to the next available one. If
+the next RFD would be number 42, then you should make the file
+file rfc-0042.md in the drafts directory. Note, that while we use four
 digits in the directories and numbering, when referring to an RFD, you
 do not need to use the leading zeros.
 

--- a/rfd/rfd-0000.md
+++ b/rfd/rfd-0000.md
@@ -106,7 +106,7 @@ there. When you start, you MUST allocate the next currently unused
 number. Note that if someone puts back to the repository before you,
 then you MUST increase your number to the next available one. If
 the next RFD would be number 42, then you should make the file
-file rfc-0042.md in the drafts directory. Note, that while we use four
+file rfd-0042.md in the drafts directory. Note, that while we use four
 digits in the directories and numbering, when referring to an RFD, you
 do not need to use the leading zeros.
 

--- a/rfd/rfd-0000.md
+++ b/rfd/rfd-0000.md
@@ -142,7 +142,7 @@ Only the `authors`, and the `state` are tracked.  There MAY be any
 number of `authors`, they MUST be listed with their name and e-mail
 address for proper attribution.
 
-An RFD can be in one of the following four states:
+An RFD can be in one of the following three states:
 
 1. draft
 1. publish

--- a/rfd/rfd-0000.md
+++ b/rfd/rfd-0000.md
@@ -112,8 +112,8 @@ do not need to use the leading zeros.
 
 ```
 $ git pull
-$ cp templates/template.md rfd/drafts/rfd-0042.md
-$ git add rfd/drafts/rfd-0042.md
+$ cp templates/template.md drafts/rfd-0042.md
+$ git add drafts/rfd-0042.md
 $ git commit
 $ git push
 ```
@@ -184,7 +184,7 @@ move the document out of the `drafts` directory, and push your changes
 
 ```
 $ cd drafts
-$ git mv rfc-0042.md ..
+$ git mv rfc-0042.md ../rfd
 $ git commit
 $ git push
 ```

--- a/rfd/rfd-0000.md
+++ b/rfd/rfd-0000.md
@@ -91,8 +91,8 @@ repository.
 What (untrusted) user input (including both data and code) will be be
 made visible to the system as part of the change?  Which components
 will interact with that input?  How will that input be validated and
-managed securely?  What new new or changes privileges will your
-feature require?  How might  an attacker use the proposed facilities to
+managed securely?  What new or changed privileges will your
+feature require?  How might an attacker use the proposed facilities to
 escalate their privileges?
 
 ## Mechanics of an RFD


### PR DESCRIPTION
Update some text that seems to be left over from an older draft, or from the original Joyent RFD definitions.