### PR TITLE
Fix hanging forward reference

### DIFF
--- a/rfd/rfd-0000.md
+++ b/rfd/rfd-0000.md
@@ -156,8 +156,8 @@ When the discussion on a document has come to a suitable and
 acceptable close it SHOULD be updated to the `publish` state.
 
 Just because something is in the `publish` state does not mean that it
-cannot be updated and corrected. See the "Touching up" section for
-more information.
+cannot be updated and corrected. See the "Changes after publishing" section
+for more information.
 
 If an RFD is not viable or if an RFD must be ignored, it can be moved
 into the `abandoned` state.


### PR DESCRIPTION
The `RFD Meta data and State` section mentions a `Touching Up` section that does not exist. Replace it with a reference to `Changes after publishing`